### PR TITLE
Adding methods to use an existing TopoDS_Shape from OCC.

### DIFF
--- a/libsrc/occ/occgeom.cpp
+++ b/libsrc/occ/occgeom.cpp
@@ -1322,6 +1322,27 @@ void STEP_GetEntityName(const TopoDS_Shape & theShape, STEPCAFControl_Reader * a
       return occgeo;
    }
 
+   // Found at https://sourceforge.net/p/netgen-mesher/discussion/905307/thread/2652dcac/
+   OCCGeometry * UseOCCGeometry ( TopoDS_Shape* shape )
+   {
+     OCCGeometry * occgeo;
+     occgeo = new OCCGeometry;
+
+     occgeo->shape = *shape;
+
+     // We do not use colour data right now.
+     // Hence, the face_colours Handle needs to be created as a NULL handle.
+     occgeo->face_colours = Handle_XCAFDoc_ColorTool();
+     occgeo->face_colours.Nullify();
+     occgeo->changed = 1;
+     occgeo->BuildFMap();
+
+     occgeo->CalcBoundingBox();
+     PrintContents (occgeo);
+
+     return occgeo;
+  }
+
 
   void OCCGeometry :: Save (string sfilename) const
   {

--- a/libsrc/occ/occgeom.hpp
+++ b/libsrc/occ/occgeom.hpp
@@ -296,6 +296,7 @@ namespace netgen
 
       DLL_HEADER void HealGeometry();
 
+
       // Philippose - 15/01/2009
       // Sets the maximum mesh size for a given face
       // (Note: Local mesh size limited by the global max mesh size)
@@ -433,6 +434,7 @@ namespace netgen
    DLL_HEADER OCCGeometry * LoadOCC_IGES (const char * filename);
    DLL_HEADER OCCGeometry * LoadOCC_STEP (const char * filename);
    DLL_HEADER OCCGeometry * LoadOCC_BREP (const char * filename);
+   DLL_HEADER OCCGeometry * UseOCCGeometry(TopoDS_Shape* shape);
 
    DLL_HEADER extern OCCParameters occparam;
 

--- a/nglib/nglib.cpp
+++ b/nglib/nglib.cpp
@@ -796,8 +796,16 @@ namespace nglib
    }
 
 
+   DLL_HEADER Ng_OCC_Geometry * Ng_UseOCCGeometry ( Ng_OCC_Shape shape )
+   {
+     // Call the function to use OCC shape. Note.. the geometry class
+     // is created and instantiated within that function
+     OCCGeometry * occgeo = UseOCCGeometry( (TopoDS_Shape*) shape );
 
+     return ((Ng_OCC_Geometry *)occgeo);
+   }
    
+
    // Loads geometry from STEP File
    DLL_HEADER Ng_OCC_Geometry * Ng_OCC_Load_STEP (const char * filename)
    {

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -61,6 +61,7 @@ typedef void * Ng_STL_Geometry;
 /// Data type for NETGEN OpenCascade geometry
 typedef void * Ng_OCC_Geometry;
 typedef void * Ng_OCC_TopTools_IndexedMapOfShape;
+typedef void * Ng_OCC_Shape;
 #endif
 
 
@@ -660,6 +661,9 @@ DLL_HEADER Ng_OCC_Geometry * Ng_OCC_NewGeometry ();
 
 // Delete an OCC Geometry Object
 DLL_HEADER Ng_Result Ng_OCC_DeleteGeometry (Ng_OCC_Geometry * geom);
+
+// Use OpenCascade TopoDS_Shape shape as geometry
+DLL_HEADER Ng_OCC_Geometry * Ng_UseOCCGeometry(Ng_OCC_Shape shape);
 
 // Loads geometry from STEP file
 DLL_HEADER Ng_OCC_Geometry * Ng_OCC_Load_STEP (const char * filename);


### PR DESCRIPTION
1. Added a new interface in nglib.cpp/h, Ng_UseOCCGeometry, which takes an Ng_OCC_Shape (which is a converted to TopoDS_Shape *) and returns an Ng_OCC_Geometry pointer.
2. In occgeom.hpp/occgeom.cpp, added UseOCCGeometry, which takes a TopoDS_Shape and returns an OCCGeometry object.