### PR TITLE
avoid compiler warning about missing return statement

### DIFF
--- a/ng/encoding.hpp
+++ b/ng/encoding.hpp
@@ -235,6 +235,7 @@ class Mpeg {
         sws_ctx = sws_getContext( width, height, AV_PIX_FMT_RGB24,
                                  width, height, AV_PIX_FMT_YUV420P,
                                  SWS_BICUBIC, NULL, NULL, NULL );
+        return 0;
     }
 
     void Stop() {


### PR DESCRIPTION
current gcc versions return a random value here what can be seen
as security problem (SUSE distro checks complain here therefore)