### PR TITLE
unv interface for 2D case

### DIFF
--- a/libsrc/interface/readuser.cpp
+++ b/libsrc/interface/readuser.cpp
@@ -127,7 +127,7 @@ namespace netgen
 		cout << "read " << mesh.GetNP() << " points" << endl;
                 Point3d pmin, pmax;
                 mesh.GetBox (pmin, pmax);
-                if(fabs(pmin.Z() - pmax.Z()) < 1e-10) //hard-coded for now
+                if(fabs(pmin.Z() - pmax.Z()) < 1e-10 * Dist(pmin, pmax))
                 {
                        cout << "Set Dimension to 2." << endl;
                        mesh.SetDimension(2);
@@ -167,14 +167,14 @@ namespace netgen
                           el[2] = -1;
 
                           if(dim == 3){
-                          auto nr = tmp_segments.Size();
-                          tmp_segments.Append(el);
-                          element_map[label] = std::make_tuple(nr+1, 2);
+                            auto nr = tmp_segments.Size();
+                            tmp_segments.Append(el);
+                            element_map[label] = std::make_tuple(nr+1, 2);
                           }
                           else if(dim == 2){
-		          el.si = -1; // add label to segment, will be changed later when BC's are assigned
-                          auto nr = mesh.AddSegment(el);
-                          element_map[label] = std::make_tuple(nr+1, 2);
+		            el.si = -1; // add label to segment, will be changed later when BC's are assigned
+                            auto nr = mesh.AddSegment(el);
+                            element_map[label] = std::make_tuple(nr+1, 2);
                           }
                           break;
                         }
@@ -186,18 +186,26 @@ namespace netgen
                           el[1] = nodes[2];
                           el[2] = nodes[1];
                           
-                          auto nr = tmp_segments.Size();
-                          tmp_segments.Append(el);
-                          element_map[label] = std::make_tuple(nr+1, 2);
+                          if(dim == 3){
+                            auto nr = tmp_segments.Size();
+                            tmp_segments.Append(el);
+                            element_map[label] = std::make_tuple(nr+1, 2);
+                          }
+                          else if(dim == 2){
+		            el.si = -1; // add label to segment, will be changed later when BC's are assigned
+                            auto nr = mesh.AddSegment(el);
+                            element_map[label] = std::make_tuple(nr+1, 2);
+                          }
+
                           break;
                         }
 		      case 41: // TRIG
 			{
 			  Element2d el (TRIG);
-			  el.SetIndex(1);
+			  el.SetIndex (1);
 			  for (int j = 0; j < nnodes; j++)
 			    el[j] = nodes[j];
-			  auto nr = mesh.AddSurfaceElement(el);
+			  auto nr = mesh.AddSurfaceElement (el);
                           element_map[label] = std::make_tuple(nr+1, 1);
 			  break;
 			}

--- a/libsrc/interface/readuser.cpp
+++ b/libsrc/interface/readuser.cpp
@@ -382,7 +382,7 @@ namespace netgen
 		// loop through segments to assign default BC to unmarked edges
 		int bccounter_tmp = bccounter;
 		for(int index=1; index <= mesh.GetNSeg(); index++){
-                	Segment & seg = mesh.LineSegment(get<0>(element_map[index]));
+                	Segment & seg = mesh.LineSegment(index);
 			if(seg.si == -1){
 			  seg.si = bccounter + 1;
 			  if(bccounter_tmp == bccounter) mesh.SetBCName(bccounter, "default"); // could be more efficient

--- a/libsrc/interface/readuser.cpp
+++ b/libsrc/interface/readuser.cpp
@@ -97,7 +97,7 @@ namespace netgen
         // map from unv element nr to our element number + an index if it is vol (0), bnd(1), ...
         std::map<size_t, std::tuple<size_t, int>> element_map;
 	int dim = 3;
-	int bccounter = 0; // for 2D case
+	int bccounter = 0;
 
         NgArray<Segment> tmp_segments;
         while (in.good())
@@ -284,11 +284,12 @@ namespace netgen
                         {
                           if(dim == 3)
                           {
-                            int bcpr = mesh.GetNFD()+1;
+                            int bcpr = mesh.GetNFD();
                             fdnr = mesh.AddFaceDescriptor(FaceDescriptor(bcpr, 0,0,0));
                             mesh.GetFaceDescriptor(fdnr).SetBCProperty(bcpr+1);
                             mesh.SetBCName(bcpr, name);
                             mesh.SurfaceElement(get<0>(element_map[index])).SetIndex(fdnr);
+                            bccounter++;
                           }
                           else if(dim == 2)
                           {
@@ -399,6 +400,7 @@ namespace netgen
         mesh.RebuildSurfaceElementLists();
         mesh.GetBox (pmin, pmax);
         mesh.UpdateTopology();
+        if(dim == 3) bccounter++;
         cout << "bounding-box = " << pmin << "-" << pmax << endl;
 	cout << "Created " << bccounter << " boundaries." << endl;
 	for(int i=0; i<bccounter; i++){

--- a/libsrc/interface/readuser.cpp
+++ b/libsrc/interface/readuser.cpp
@@ -4,8 +4,6 @@
 
 
 #include <mystdlib.h>
-
-
 #include <myadt.hpp>
 #include <linalg.hpp>
 #include <csg.hpp>
@@ -242,6 +240,7 @@ namespace netgen
                   }
                 cout << mesh.GetNE() << " elements found" << endl;
                 cout << mesh.GetNSE() << " surface elements found" << endl;
+
               }
             else if(strcmp (reco, "2467") == 0)
               {
@@ -374,11 +373,11 @@ namespace netgen
 	if(dim == 2){
 		// loop through segments to assign default BC to unmarked edges
 		int bccounter_tmp = bccounter;
-		for(int index=0; index < mesh.GetNSeg(); index++){
+		for(int index=1; index <= mesh.GetNSeg(); index++){
                 	Segment & seg = mesh.LineSegment(get<0>(element_map[index]));
 			if(seg.si == -1){
-			  seg.si = bccounter;
-			  mesh.SetBCName(bccounter, "default"); // could be more efficient
+			  seg.si = bccounter + 1;
+			  if(bccounter_tmp == bccounter) mesh.SetBCName(bccounter, "default"); // could be more efficient
 			  seg.SetBCName(mesh.GetBCNamePtr(bccounter));
 			  bccounter_tmp++;
 			}
@@ -397,7 +396,6 @@ namespace netgen
 	for(int i=0; i<bccounter; i++){
 		cout << mesh.GetBCName(i) << endl;
 	}
-
       }
 
 


### PR DESCRIPTION
In the 2D case, the unv interface does not recognize segments and faces properly to assign materials and BCs.

This is a fix that seems to work if all edges for BCs are marked.
