### PR TITLE
After adding edges in Ng_STL_InitSTLGeometry, set readedges size to 0.

### DIFF
--- a/nglib/nglib.cpp
+++ b/nglib/nglib.cpp
@@ -632,6 +632,7 @@ namespace nglib
          }
          */
          geo->AddEdges(readedges);
+	 readedges.SetSize(0);
       }
 
       if (geo->GetStatus() == STLTopology::STL_GOOD || geo->GetStatus() == STLTopology::STL_WARNING) return NG_OK;


### PR DESCRIPTION
The global variable readedges that the API uses doesn't clear itself after the Ng_STL_Geometry * has been initialized.
It would cause problems for people who wish to initialize another Ng_STL_Geometry if they used Ng_STL_AddEdge in before their previous initialization.