### PR TITLE
Add FromOCC (const TopoDS_Shape& s)

### DIFF
--- a/libsrc/occ/occgeom.cpp
+++ b/libsrc/occ/occgeom.cpp
@@ -1670,6 +1670,23 @@ namespace netgen
       return occgeo;
    }
 
+   OCCGeometry *FromOCC (const TopoDS_Shape& s)
+   {
+      OCCGeometry * occgeo;
+      occgeo = new OCCGeometry;
+
+      occgeo->shape = s;
+
+      occgeo->face_colours = Handle_XCAFDoc_ColorTool();
+      occgeo->face_colours.Nullify();
+      occgeo->changed = 1;
+      occgeo->BuildFMap();
+
+      occgeo->CalcBoundingBox();
+      PrintContents (occgeo);
+
+      return occgeo;
+   }
 
   void OCCGeometry :: Save (string sfilename) const
   {

--- a/libsrc/occ/occgeom.hpp
+++ b/libsrc/occ/occgeom.hpp
@@ -452,6 +452,8 @@ namespace netgen
   DLL_HEADER OCCGeometry * LoadOCC_IGES (const char * filename);
   DLL_HEADER OCCGeometry * LoadOCC_STEP (const char * filename);
   DLL_HEADER OCCGeometry * LoadOCC_BREP (const char * filename);
+  DLL_HEADER OCCGeometry * FromOCC (const TopoDS_Shape& s);
+
 
   // Philippose - 31.09.2009
   // External access to the mesh generation functions within the OCC

--- a/libsrc/occ/python_occ.cpp
+++ b/libsrc/occ/python_occ.cpp
@@ -65,6 +65,13 @@ DLL_HEADER void ExportNgOCC(py::module &m)
                     return geo;
                   }), py::arg("filename"),
         "Load OCC geometry from step, brep or iges file")
+    .def(py::init([] ( const TopoDS_Shape* s)
+                  {
+                    shared_ptr<OCCGeometry> geo;
+                    geo.reset(FromOCC(*s));
+                    return geo;
+                  }), py::arg("shape"),
+        "Load OCC geometry from an existing TopoDS_Shape object")
     .def(NGSPickle<OCCGeometry>())
     .def("Glue", &OCCGeometry::GlueGeometry)
     .def("Heal",[](OCCGeometry & self, double tolerance, bool fixsmalledges, bool fixspotstripfaces, bool sewfaces, bool makesolids, bool splitpartitions)

--- a/libsrc/occ/python_occ.cpp
+++ b/libsrc/occ/python_occ.cpp
@@ -65,10 +65,10 @@ DLL_HEADER void ExportNgOCC(py::module &m)
                     return geo;
                   }), py::arg("filename"),
         "Load OCC geometry from step, brep or iges file")
-    .def(py::init([] ( const TopoDS_Shape* s)
+    .def(py::init([] ( const TopoDS_Shape& s)
                   {
                     shared_ptr<OCCGeometry> geo;
-                    geo.reset(FromOCC(*s));
+                    geo.reset(FromOCC(s));
                     return geo;
                   }), py::arg("shape"),
         "Load OCC geometry from an existing TopoDS_Shape object")


### PR DESCRIPTION
This will allow using Netgen together with OCCT or python bindings like [pyOCCT](https://github.com/trelau/pyOCCT) or [OCP](https://github.com/CadQuery/OCP) without writing to disk.

NB: same functionality as in  #11 
CC: @trelau