### PR TITLE
cmake: add a variable to skip Debian-isms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,7 @@ endif(USE_NATIVE_ARCH)
 #######################################################################
 # Debian packager
 
-if(UNIX)
+if(UNIX AND NOT NETGEN_NO_DEB_PACKAGER)
     set(CPACK_SOURCE_GENERATOR "TGZ")
     set(CPACK_SOURCE_IGNORE_FILES "/cmake/;/build/;/.gz/;~$;${CPACK_SOURCE_IGNORE_FILES}")
     set(CPACK_PACKAGE_VERSION ${PACKAGE_VERSION} )


### PR DESCRIPTION
Not every Linux machine is Debian-based.

---
This variable is hidden, but can be set in case these things trigger errors elsewhere.