### PR TITLE
Exposed parameters to Ng_Meshing_Parameters (nglib.h)

### DIFF
--- a/nglib/nglib.cpp
+++ b/nglib/nglib.cpp
@@ -1013,6 +1013,17 @@ namespace nglib
 
       check_overlap = 1;
       check_overlapping_boundary = 1;
+
+      parthreadenable = 0;
+      nthreads = 4;
+
+      surfcurvfact = 2;
+      chartdistfact = 1.2;
+      edgeanglefact = 1;
+      surfmeshcurvfact = 1;
+      linelengthfact = 0.5;
+
+      stlgeom_tol_fact = 1E-6;
    }
 
 
@@ -1054,6 +1065,17 @@ namespace nglib
 
       check_overlap = 1;
       check_overlapping_boundary = 1;
+
+      parthreadenable = 0;
+      nthreads = 4;
+
+      surfcurvfact = 2;
+      chartdistfact = 1.2;
+      edgeanglefact = 1;
+      surfmeshcurvfact = 1;
+      linelengthfact = 0.5;
+
+      stlgeom_tol_fact = 1E-6;
    }
 
 
@@ -1086,6 +1108,17 @@ namespace nglib
 
       mparam.checkoverlap = check_overlap;
       mparam.checkoverlappingboundary = check_overlapping_boundary;
+
+      mparam.parthread = parthreadenable;
+      mparam.nthreads = nthreads;
+
+      stlparam.resthsurfcurvfac = surfcurvfact;
+      stlparam.resthchartdistfac = chartdistfact;
+      stlparam.resthedgeanglefac = edgeanglefact;
+      stlparam.resthsurfmeshcurvfac = surfmeshcurvfact;
+      stlparam.resthlinelengthfac = linelengthfact;
+
+      stldoctor.geom_tol_fact = stlgeom_tol_fact;
    }
    // ------------------ End - Meshing Parameters related functions --------------------
 

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -130,6 +130,20 @@ public:
    int check_overlap;                  //!< Check for overlapping surfaces during Surface meshing
    int check_overlapping_boundary;     //!< Check for overlapping surface elements before volume meshing
 
+   // Nikhil - 29/09/2020
+   // Added a couple more parameters into the meshing parameters list
+   // from Netgen into Nglib
+   int parthreadenable;                 //!< Enable / Disable parallel threads
+   int nthreads;                        //!< Set number of threads to use
+
+   double surfcurvfact;                 //!< Set STL - surface curvature
+   double chartdistfact;                //!< Set STL - chart distance
+   double edgeanglefact;                //!< Set STL - edge angle
+   double surfmeshcurvfact;             //!< Set STL - surface mesh curv
+   double linelengthfact;               //!< Set STL - line length
+
+   double stlgeom_tol_fact;             //!< Set the point tolerance in STL files
+
 
    /*!
       Default constructor for the Mesh Parameters class
@@ -155,6 +169,8 @@ public:
       - #invert_trigs:0 
       - #check_overlap: 1
       - #check_overlapping_boundary: 1
+      - #parthreadenable: 0
+      - #nthreads: 4
    */
    DLL_HEADER Ng_Meshing_Parameters();
 

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -171,6 +171,12 @@ public:
       - #check_overlapping_boundary: 1
       - #parthreadenable: 0
       - #nthreads: 4
+      - #surfcurvfact: 2
+      - #chartdistfact: 1.2
+      - #edgeanglefact: 1
+      - #surfmeshcurvfact: 1
+      - #linelengthfact: 0.5
+      - #stlgeom_tol_fact: 1E-6
    */
    DLL_HEADER Ng_Meshing_Parameters();
 


### PR DESCRIPTION
## Exposed parameters for parallel meshing, stl point tolerance, and granularity:

### Parallel meshing
- netgen::MeshingParameters::parthread
- netgen::MeshingParameters::nthreads

### Granularity
- netgen::STLParameters netgen::stlparam::resthsurfcurvfac
- netgen::STLParameters netgen::stlparam::resthchartdistfac
- netgen::STLParameters netgen::stlparam::resthedgeanglefac
- netgen::STLParameters netgen::stlparam::resthsurfmeshcurvfac
- netgen::STLParameters netgen::stlparam::resthlinelengthfac

### Point tolerance
- netgen::STLDoctorParams::geom_tol_fact