### PR TITLE
Apply some cleanups from SALOME downstream patch

### DIFF
--- a/libsrc/gprim/geom2d.cpp
+++ b/libsrc/gprim/geom2d.cpp
@@ -3,10 +3,6 @@
 #include <myadt.hpp>
 #include <gprim.hpp>
 
-#ifndef M_PI
-#define M_PI        3.14159265358979323846
-#endif
-
 namespace netgen
 {
 

--- a/libsrc/gprim/geomfuncs.cpp
+++ b/libsrc/gprim/geomfuncs.cpp
@@ -83,7 +83,7 @@ double Det (const Mat<3,3> & m)
 
 void EigenValues (const Mat<3,3> & m, Vec<3> & ev)
 {
-  const double pi = 3.141592;
+  const double pi = M_PI;
   double a, b, c, d;
   double p, q;
   double arg;

--- a/libsrc/occ/CMakeLists.txt
+++ b/libsrc/occ/CMakeLists.txt
@@ -2,7 +2,7 @@ add_definitions(-DNGINTERFACE_EXPORTS)
 add_library(occ ${NG_LIB_TYPE}
         Partition_Inter2d.cxx Partition_Inter3d.cxx 
         Partition_Loop.cxx Partition_Loop2d.cxx Partition_Loop3d.cxx Partition_Spliter.cxx 
-        occconstruction.cpp occgenmesh.cpp occgeom.cpp occmeshsurf.cpp python_occ.cpp
+        occgenmesh.cpp occgeom.cpp occmeshsurf.cpp python_occ.cpp
         )
 if(USE_GUI)
         add_library(occvis ${NG_LIB_TYPE} vsocc.cpp)

--- a/libsrc/occ/Partition_Loop2d.cxx
+++ b/libsrc/occ/Partition_Loop2d.cxx
@@ -52,8 +52,6 @@
 #include <gp_Pnt.hxx>
 #include <gp_Pnt2d.hxx>
 
-#define PI 3.14159265358979323846
-
 //=======================================================================
 //function : Partition_Loop2d
 //purpose  :

--- a/libsrc/occ/occgenmesh.cpp
+++ b/libsrc/occ/occgenmesh.cpp
@@ -244,9 +244,6 @@ namespace netgen
     hvalue[0] = 0;
     pnt = c->Value(s0);
 
-    double olddist = 0;
-    double dist = 0;
-
     int tmpVal = (int)(DIVIDEEDGESECTIONS);
 
     for (int i = 1; i <= tmpVal; i++)
@@ -259,9 +256,6 @@ namespace netgen
 
         //(*testout) << "mesh.GetH(Point3d(pnt.X(), pnt.Y(), pnt.Z())) " << mesh.GetH(Point3d(pnt.X(), pnt.Y(), pnt.Z()))
         //	   <<  " pnt.Distance(oldpnt) " << pnt.Distance(oldpnt) << endl;
-
-        olddist = dist;
-        dist = pnt.Distance(oldpnt);
       }
 
     //  nsubedges = int(ceil(hvalue[DIVIDEEDGESECTIONS]));

--- a/libsrc/occ/occgeom.cpp
+++ b/libsrc/occ/occgeom.cpp
@@ -282,7 +282,7 @@ namespace netgen
       double surfacecont = 0;
       
       {
-         Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+         Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
          rebuild->Apply(shape);
          for (exp1.Init (shape, TopAbs_EDGE); exp1.More(); exp1.Next())
          {
@@ -313,7 +313,7 @@ namespace netgen
          cout << endl << "- repairing faces" << endl;
 
          Handle(ShapeFix_Face) sff;
-         Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+         Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
          rebuild->Apply(shape);
 
 
@@ -370,7 +370,7 @@ namespace netgen
 
 
       {
-         Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+         Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
          rebuild->Apply(shape);
          for (exp1.Init (shape, TopAbs_EDGE); exp1.More(); exp1.Next())
          {
@@ -387,7 +387,7 @@ namespace netgen
          cout << endl << "- fixing small edges" << endl;
 
          Handle(ShapeFix_Wire) sfw;
-         Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+         Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
          rebuild->Apply(shape);
 
 
@@ -454,7 +454,7 @@ namespace netgen
 
          {
             BuildFMap();
-            Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+            Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
             rebuild->Apply(shape);
 
             for (exp1.Init (shape, TopAbs_EDGE); exp1.More(); exp1.Next())
@@ -482,7 +482,7 @@ namespace netgen
 
 
          {
-            Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+            Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
             rebuild->Apply(shape);
             for (exp1.Init (shape, TopAbs_EDGE); exp1.More(); exp1.Next())
             {
@@ -608,7 +608,7 @@ namespace netgen
 
 
       {
-         Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+         Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
          rebuild->Apply(shape);
          for (exp1.Init (shape, TopAbs_EDGE); exp1.More(); exp1.Next())
          {
@@ -653,7 +653,7 @@ namespace netgen
                   TopoDS_Solid solid = TopoDS::Solid(exp0.Current());
                   TopoDS_Solid newsolid = solid;
                   BRepLib::OrientClosedSolid (newsolid);
-                  Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+                  Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
                   //		  rebuild->Apply(shape);
                   rebuild->Replace(solid, newsolid);
                   TopoDS_Shape newshape = rebuild->Apply(shape, TopAbs_COMPSOLID);//, 1);
@@ -1076,7 +1076,7 @@ namespace netgen
             TopoDS_Solid solid = TopoDS::Solid(exp0.Current());
             TopoDS_Solid newsolid = solid;
             BRepLib::OrientClosedSolid (newsolid);
-            Handle_ShapeBuild_ReShape rebuild = new ShapeBuild_ReShape;
+            Handle(ShapeBuild_ReShape) rebuild = new ShapeBuild_ReShape;
             rebuild->Replace(solid, newsolid);
 
             TopoDS_Shape newshape = rebuild->Apply(shape, TopAbs_SHAPE, 1);
@@ -1408,10 +1408,10 @@ namespace netgen
       static Timer timer_getnames("LoadOCC-get names");
 
       // Initiate a dummy XCAF Application to handle the STEP XCAF Document
-      static Handle_XCAFApp_Application dummy_app = XCAFApp_Application::GetApplication();
+      static Handle(XCAFApp_Application) dummy_app = XCAFApp_Application::GetApplication();
 
       // Create an XCAF Document to contain the STEP file itself
-      Handle_TDocStd_Document step_doc;
+      Handle(TDocStd_Document) step_doc;
 
       // Check if a STEP File is already open under this handle, if so, close it to prevent
       // Segmentation Faults when trying to create a new document
@@ -1441,8 +1441,8 @@ namespace netgen
       timer_transfer.Stop();
 
       // Read in the shape(s) and the colours present in the STEP File
-      Handle_XCAFDoc_ShapeTool step_shape_contents = XCAFDoc_DocumentTool::ShapeTool(step_doc->Main());
-      Handle_XCAFDoc_ColorTool step_colour_contents = XCAFDoc_DocumentTool::ColorTool(step_doc->Main());
+      Handle(XCAFDoc_ShapeTool) step_shape_contents = XCAFDoc_DocumentTool::ShapeTool(step_doc->Main());
+      Handle(XCAFDoc_ColorTool) step_colour_contents = XCAFDoc_DocumentTool::ColorTool(step_doc->Main());
 
       TDF_LabelSequence step_shapes;
       step_shape_contents->GetShapes(step_shapes);
@@ -1567,10 +1567,10 @@ namespace netgen
       OCCGeometry *occgeo;
       occgeo = new OCCGeometry;
       // Initiate a dummy XCAF Application to handle the IGES XCAF Document
-      static Handle_XCAFApp_Application dummy_app = XCAFApp_Application::GetApplication();
+      static Handle(XCAFApp_Application) dummy_app = XCAFApp_Application::GetApplication();
 
       // Create an XCAF Document to contain the IGES file itself
-      Handle_TDocStd_Document iges_doc;
+      Handle(TDocStd_Document) iges_doc;
 
       // Check if a IGES File is already open under this handle, if so, close it to prevent
       // Segmentation Faults when trying to create a new document
@@ -1596,8 +1596,8 @@ namespace netgen
       reader.Transfer(iges_doc);
 
       // Read in the shape(s) and the colours present in the IGES File
-      Handle_XCAFDoc_ShapeTool iges_shape_contents = XCAFDoc_DocumentTool::ShapeTool(iges_doc->Main());
-      Handle_XCAFDoc_ColorTool iges_colour_contents = XCAFDoc_DocumentTool::ColorTool(iges_doc->Main());
+      Handle(XCAFDoc_ShapeTool) iges_shape_contents = XCAFDoc_DocumentTool::ShapeTool(iges_doc->Main());
+      Handle(XCAFDoc_ColorTool) iges_colour_contents = XCAFDoc_DocumentTool::ColorTool(iges_doc->Main());
 
       TDF_LabelSequence iges_shapes;
       iges_shape_contents->GetShapes(iges_shapes);
@@ -1667,7 +1667,7 @@ namespace netgen
       // Fixed a bug in the OpenCascade XDE Colour handling when 
       // opening BREP Files, since BREP Files have no colour data.
       // Hence, the face_colours Handle needs to be created as a NULL handle.
-      occgeo->face_colours = Handle_XCAFDoc_ColorTool();
+      occgeo->face_colours = Handle(XCAFDoc_ColorTool)();
       occgeo->face_colours.Nullify();
       occgeo->changed = 1;
       occgeo->BuildFMap();

--- a/libsrc/occ/occgeom.hpp
+++ b/libsrc/occ/occgeom.hpp
@@ -221,7 +221,7 @@ namespace netgen
     // OpenCascade XDE Support
     // XCAF Handle to make the face colours available to the rest of
     // the system
-    Handle_XCAFDoc_ColorTool face_colours;
+    Handle(XCAFDoc_ColorTool) face_colours;
      
     mutable int changed;
     mutable NgArray<int> facemeshstatus;


### PR DESCRIPTION
SALOME NETGENPlugin currently uses a patched Netgen 5.3.1. The patch is about 1500 lines, but a lot of these changes are already included in NG 6.2.x, or are no longer relevant.

I have separated a few trivial changes which are not yet part of current NG. This hopefully helps to move SALOME to a current NG version.
