### PR TITLE
Set explicit OBJECT library type for internal togl

### DIFF
--- a/ng/Togl2.1/CMakeLists.txt
+++ b/ng/Togl2.1/CMakeLists.txt
@@ -20,7 +20,7 @@ else(WIN32)
   include_directories(BEFORE "${TCL_INCLUDE_PATH}") 
   include_directories(BEFORE "${TK_INCLUDE_PATH}") 
 
-  add_library(togl togl.c toglProcAddr.c toglStubInit.c)
+  add_library(togl OBJECT togl.c toglProcAddr.c toglStubInit.c)
   target_link_libraries(togl ${TCL_STUB_LIBRARY} ${TK_STUB_LIBRARY})
 endif(WIN32)
 


### PR DESCRIPTION
On UNIX systems, the togl library should be statically linked. When the
type is not set explicitly, this would default to SHARED when
-DBUILD_SHARED_LIBS:BOOL=ON is set.