### PR TITLE
Fix UB when control reaches end of non-void function

### DIFF
--- a/libsrc/csg/solid.cpp
+++ b/libsrc/csg/solid.cpp
@@ -194,6 +194,7 @@ namespace netgen
       case ROOT:
 	return s1->PointInSolid (p, eps);
       }
+      throw Exception("PointInSolid: invalid op");
   }
 
   
@@ -213,6 +214,7 @@ namespace netgen
       case ROOT:
 	return s1->VecInSolid (p, v, eps);
       }
+      throw Exception("VecInSolid: invalid op");
   }
   
   // checks if lim s->0 lim t->0  p + t(v1 + s v2) in solid
@@ -233,6 +235,7 @@ namespace netgen
       case ROOT:
 	return s1->VecInSolid2 (p, v1, v2, eps);
       }
+      throw Exception("VecInSolid2: invalid op");
   }
 
   

--- a/libsrc/occ/python_occ_shapes.cpp
+++ b/libsrc/occ/python_occ_shapes.cpp
@@ -194,6 +194,7 @@ py::object CastShape(const TopoDS_Shape & s)
     case TopAbs_SHAPE:
       return py::cast(s);
     }
+    throw Exception("Invalid Shape type");
 };
 
 


### PR DESCRIPTION
An enum in C/C++ can hold any value its underlying type can hold, so its theoretically possible the value is not handled in the switch statement, and the function ends without any return.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87951 for a lengthy discussion.

Catch this by throwing an exception. This allows to build the code with "-Werror=return-type".