### PR TITLE
Fix use of unitialized stlgeometry member in constructor

### DIFF
--- a/libsrc/stlgeom/vsstl.cpp
+++ b/libsrc/stlgeom/vsstl.cpp
@@ -21,7 +21,6 @@ namespace netgen
 
 /* *********************** Draw STL Geometry **************** */
 
-extern STLGeometry * stlgeometry;
 DLL_HEADER extern shared_ptr<Mesh> mesh;
 
 
@@ -33,8 +32,6 @@ VisualSceneSTLMeshing :: VisualSceneSTLMeshing ()
 {
   selecttrig = 0;
   nodeofseltrig = 1;
-  stlgeometry->SetSelectTrig(selecttrig);
-  stlgeometry->SetNodeOfSelTrig(nodeofseltrig);
 }
 
 VisualSceneSTLMeshing :: ~VisualSceneSTLMeshing ()

--- a/libsrc/stlgeom/vsstl.hpp
+++ b/libsrc/stlgeom/vsstl.hpp
@@ -13,7 +13,7 @@ namespace netgen
  class NGGUI_API VisualSceneSTLGeometry : public VisualScene
   {
     NgArray<int> trilists;
-    class STLGeometry * stlgeometry;
+    class STLGeometry * stlgeometry = nullptr;
 
   public:
     VisualSceneSTLGeometry ();
@@ -29,7 +29,7 @@ namespace netgen
   {
     NgArray<int> trilists;
     int selecttrig, nodeofseltrig;
-    class STLGeometry * stlgeometry;
+    class STLGeometry * stlgeometry = nullptr;
 
   public:
     VisualSceneSTLMeshing ();

--- a/libsrc/visualization/stlmeshing.cpp
+++ b/libsrc/visualization/stlmeshing.cpp
@@ -19,7 +19,6 @@ namespace netgen
 
 /* *********************** Draw STL Geometry **************** */
 
-extern STLGeometry * stlgeometry;
 extern AutoPtr<Mesh> mesh;
 
 
@@ -33,8 +32,6 @@ VisualSceneSTLMeshing :: VisualSceneSTLMeshing ()
 {
   selecttrig = 0;
   nodeofseltrig = 1;
-  stlgeometry->SetSelectTrig(selecttrig);
-  stlgeometry->SetNodeOfSelTrig(nodeofseltrig);
 }
 
 VisualSceneSTLMeshing :: ~VisualSceneSTLMeshing ()


### PR DESCRIPTION
stlgeometry is a private member of VisualSceneSTLGeometry/Meshing, and
can't point to any valid geometry when the constructor runs, so remove
any dereferences there.

Remove the misleading extern declaration of netgen::stlgeometry.