### PR TITLE
Fix segmentation fault introduced in 78dfd10: missing local variable name was causing the global variable to be used

### DIFF
--- a/libsrc/occ/python_occ.cpp
+++ b/libsrc/occ/python_occ.cpp
@@ -251,7 +251,7 @@ DLL_HEADER void ExportNgOCC(py::module &m)
          }, py::call_guard<py::gil_scoped_release>())
     .def("GenerateMesh", [](shared_ptr<OCCGeometry> geo,
                             MeshingParameters* pars, NgMPI_Comm comm,
-                            shared_ptr<Mesh>, py::kwargs kwargs)
+                            shared_ptr<Mesh> mesh, py::kwargs kwargs)
                          {
                            MeshingParameters mp;
                            OCCParameters occparam;


### PR DESCRIPTION
I believe 78dfd10 introduced a regression due to a small mistake.

I've noticed this while running my test suite at [FEM on Colab](https://fem-on-colab.github.io/)
To reproduce, download and run
https://github.com/fem-on-colab/fem-on-colab/raw/main/ngsolve/test-ngsolve-extras.ipynb
which will crash at the cell
```
mesh = Mesh(unit_square.GenerateMesh(maxh=0.2))
Draw(mesh);
```

You will notice that in that file I collect a few of your tutorials for my CI: running the failing cell alone (plus the corresponding imports a couple of cells above) will *not* cause a segmentation fault, while running the entire notebook will cause a segmentation fault. I am not knowledgeable enough in netgen/ngsolve to understand why. 

cc @ChrLackner 