### PR TITLE
Export OCC shape in BREP file

### DIFF
--- a/libsrc/occ/python_occ_shapes.cpp
+++ b/libsrc/occ/python_occ_shapes.cpp
@@ -787,6 +787,10 @@ DLL_HEADER void ExportNgOCCShapes(py::module &m)
             { step_utils::WriteSTEP(shape, filename); }
          , py::arg("filename"), "export shape in STEP - format")
 
+    .def("Write", [](const TopoDS_Shape & shape, string & filename)
+            { BRepTools::Write(shape, filename.c_str()); }
+         , py::arg("filename"), "export shape in BREP - format")
+
     .def("bc", [](const TopoDS_Shape & shape, const string & name)
          {
            for (TopExp_Explorer e(shape, TopAbs_FACE); e.More(); e.Next())


### PR DESCRIPTION
The OCC kernel consumes a lot of memory.
We found this problematic for MPI simulations using curved elements, which is done by loading a mesh and setting the geometry.
As for the no naming of boundaries etc. is required for curving the mesh, we found that only exporting the geometry in a BREP file circumvents this problem. So far, this has not been possible in the Python API.