### PR TITLE
utils.hpp: use arch defines for Apple correctly

### DIFF
--- a/libsrc/core/utils.hpp
+++ b/libsrc/core/utils.hpp
@@ -11,7 +11,7 @@
 
 #include "ngcore_api.hpp"       // for NGCORE_API and CPU arch macros
 
-#if defined(__APPLE__) && defined(NETGEN_ARCH_ARM64)
+#if defined(__APPLE__) && !defined(NETGEN_ARCH_AMD64)
 #include <mach/mach_time.h>
 #endif
 
@@ -62,7 +62,7 @@ namespace ngcore
 
   inline TTimePoint GetTimeCounter() noexcept
   {
-#if defined(__APPLE__) && defined(NETGEN_ARCH_ARM64)
+#if defined(__APPLE__) && !defined(NETGEN_ARCH_AMD64)
     return mach_absolute_time();
 #elif defined(NETGEN_ARCH_AMD64)
     return __rdtsc();


### PR DESCRIPTION
Existing code unnecessarily excludes PowerPC. Change the macro so that it has the desired effect.

For the reference, `mach_absolute_time` is supported from 10.0: https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time