### PR TITLE
encoding.hpp: define __STDC_FORMAT_MACROS, include cinttypes

### DIFF
--- a/ng/encoding.hpp
+++ b/ng/encoding.hpp
@@ -3,6 +3,11 @@
 
 #ifdef FFMPEG
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
+
 extern "C" {
 #include <libavutil/avassert.h>
 #include <libavcodec/avcodec.h>


### PR DESCRIPTION
FFMpeg’s `timestamp.h` uses `PRId64`, which requires  `__STDC_FORMAT_MACROS` to be defined on some platforms.