### PR TITLE
use functools.wrap for the TimeFuncton wrapper.

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -49,9 +49,11 @@ def Redraw(*args, **kwargs):
     return _Redraw(*args, **kwargs)
 
 from pyngcore import Timer
+from functools import wraps
 def TimeFunction(func, name=None):
     name = name or func.__qualname__
     timer = Timer(name)
+    @wraps(func)
     def retfunc(*args,**kwargs):
         with timer:
             ret = func(*args, **kwargs)


### PR DESCRIPTION
Applying the functools.wrap decorator is good practice and remains name and docstring of the original functions.