### PR TITLE
no exporting compile options of ngcore

### DIFF
--- a/libsrc/core/CMakeLists.txt
+++ b/libsrc/core/CMakeLists.txt
@@ -53,7 +53,7 @@ if(USE_PYTHON)
 endif(USE_PYTHON)
 
 if(WIN32)
-  target_compile_options(ngcore PUBLIC /bigobj /MP /W1 /wd4068)
+  target_compile_options(ngcore PUBLIC $<BUILD_INTERFACE:/bigobj;/MP;/W1;/wd4068>)
   get_WIN32_WINNT(ver)
   target_compile_definitions(ngcore PUBLIC _WIN32_WINNT=${ver} WNT WNT_WINDOW NOMINMAX MSVC_EXPRESS _CRT_SECURE_NO_WARNINGS HAVE_STRUCT_TIMESPEC WIN32)
   target_link_options(ngcore PUBLIC /ignore:4273 /ignore:4217 /ignore:4049)

--- a/nglib/CMakeLists.txt
+++ b/nglib/CMakeLists.txt
@@ -6,7 +6,7 @@ if(USE_OCC)
 endif(USE_OCC)
 
 if(EMSCRIPTEN)
-  target_compile_options(nglib PUBLIC $<TARGET_PROPERTY:ngcore,INTERFACE_COMPILE_OPTIONS>)
+  target_compile_options(nglib PUBLIC $<BUILD_INTERFACE:$<TARGET_PROPERTY:ngcore,INTERFACE_COMPILE_OPTIONS>>)
   target_compile_definitions(nglib PUBLIC $<TARGET_PROPERTY:ngcore,INTERFACE_COMPILE_DEFINITIONS>)
   target_include_directories(nglib PUBLIC $<TARGET_PROPERTY:ngcore,INTERFACE_INCLUDE_DIRECTORIES>)
 else(EMSCRIPTEN)


### PR DESCRIPTION
The compile options of ngcore, eg: `/W1`, should not be exported, which will result in a warning [D9025](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/command-line-warning-d9025?view=msvc-170) with client code using different warning level while linking the library. The compile options should be restricted within the library building stage with cmake `$<BUILD_INTERFACE:...>`.

