### PR TITLE
Don't use allocsize uninitialized in Array(Array&&)

### DIFF
--- a/libsrc/core/array.hpp
+++ b/libsrc/core/array.hpp
@@ -731,7 +731,7 @@ namespace ngcore
       mem_to_delete = nullptr;
     }
 
-    NETGEN_INLINE Array (Array && a2) 
+    NETGEN_INLINE Array (Array && a2) : allocsize(0)
     {
       mt.Swap(sizeof(T) * allocsize, a2.mt, sizeof(T) * a2.allocsize);
 


### PR DESCRIPTION
This fixes an integer overflow error that clang++ -fsanitize caught for me, and might fix allocation failures for users with mem tracing enabled.

Refs issue #188

I'm pretty sure this patch isn't nearly large+expressive enough to be subject to copyright, but I'll get you a signed CLA shortly to be safe.