### PR TITLE
optional arm feature complex

### DIFF
--- a/libsrc/core/simd_arm64.hpp
+++ b/libsrc/core/simd_arm64.hpp
@@ -214,6 +214,7 @@ namespace ngcore
     return FNMA(SIMD<double,2> (a), b, c);
   }
 
+#ifdef __ARM_FEATURE_COMPLEX
   // ARM complex mult:
   // https://arxiv.org/pdf/1901.07294.pdf
   // c += a*b    (a0re, a0im, a1re, a1im, ...), 
@@ -231,7 +232,7 @@ namespace ngcore
     FMAComplex (a.Hi(), b.Hi(), chi);
     c = SIMD<double,4> (clo, chi);
   }
-
+#endif
   
 
   NETGEN_INLINE SIMD<double,2> operator+ (SIMD<double,2> a, SIMD<double,2> b)


### PR DESCRIPTION
ARM complex mult requires arm feature complex, which is implied by armv8.3a and simd(neon) feature, i.e "-march=armv8.3-a+simd".
This patch affects ngsolve rather than netgen since only ngsolve compile the  complex mult code.

With this patch, ngsolve should be able to built and tested on generic aarch64-linux platform.