### PR TITLE
link FFMPEG and include stdlib for gcc-14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,6 +439,9 @@ if (USE_MPEG)
     find_package(FFMPEG REQUIRED)
     add_definitions(-DFFMPEG -D__STDC_CONSTANT_MACROS)
     include_directories(${FFMPEG_INCLUDE_DIR})
+    if(USE_GUI)
+        target_link_libraries(nggui INTERFACE ${FFMPEG_LIBRARIES})
+    endif(USE_GUI)
 endif (USE_MPEG)
 
 #######################################################################

--- a/ng/encoding.hpp
+++ b/ng/encoding.hpp
@@ -3,6 +3,9 @@
 
 #ifdef FFMPEG
 
+#include <mystdlib.h>
+using namespace std;
+
 extern "C" {
 #include <libavutil/avassert.h>
 #include <libavcodec/avcodec.h>


### PR DESCRIPTION
required for building with gcc-14

applies debian patches:
include_stdlib.patch
ffmpeg_link_libraries.patch

https://salsa.debian.org/science-team/netgen/-/blob/d7ca1c564d90d00ce3d83e0b63c36fbec11cf1ce/debian/patches/include_stdlib.patch https://salsa.debian.org/science-team/netgen/-/blob/d7ca1c564d90d00ce3d83e0b63c36fbec11cf1ce/debian/patches/ffmpeg_link_libraries.patch

Fixes: #192 