### PR TITLE
fix 32-bit usage of size_t and support non-intel arches

### DIFF
--- a/libsrc/core/python_ngcore.hpp
+++ b/libsrc/core/python_ngcore.hpp
@@ -2,6 +2,7 @@
 #define NETGEN_CORE_PYTHON_NGCORE_HPP
 
 #include "ngcore_api.hpp" // for operator new
+#include <cstdint>
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 #include <pybind11/numpy.h>
@@ -182,10 +183,12 @@ namespace ngcore
     static std::string GetName() { return "D"; }
   };
 
+#if INTPTR_MAX != INT32_MAX
   template<>
   struct PyNameTraits<size_t> {
     static std::string GetName() { return "S"; }
   };
+#endif
 
   template<typename T>
   struct PyNameTraits<std::shared_ptr<T>> {

--- a/libsrc/core/python_ngcore_export.cpp
+++ b/libsrc/core/python_ngcore_export.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 #include "python_ngcore.hpp"
 #include "bitarray.hpp"
 #include "taskmanager.hpp"
@@ -23,7 +25,9 @@ PYBIND11_MODULE(pyngcore, m) // NOLINT
   catch(...) {}
   ExportArray<int>(m);
   ExportArray<unsigned>(m);
+#if INTPTR_MAX != INT32_MAX
   ExportArray<size_t>(m);
+#endif
   ExportArray<double>(m);
   ExportArray<float>(m);
   ExportArray<signed short>(m);

--- a/libsrc/core/table.hpp
+++ b/libsrc/core/table.hpp
@@ -8,6 +8,7 @@
 /**************************************************************************/
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <optional>
 
@@ -104,8 +105,10 @@ namespace ngcore
   { return TablePrefixSum32 (FlatArray<unsigned> (entrysize.Size(), (unsigned int*)(int*)(entrysize.Addr(0)))); }
   NETGEN_INLINE size_t * TablePrefixSum (FlatArray<std::atomic<int>> entrysize)
   { return TablePrefixSum32 (FlatArray<unsigned> (entrysize.Size(), (unsigned int*)(std::atomic<int>*)entrysize.Addr(0))); }
+#if INTPTR_MAX != INT32_MAX
   NETGEN_INLINE size_t * TablePrefixSum (FlatArray<size_t> entrysize)
   { return TablePrefixSum64 (entrysize); }
+#endif
 
 
   /**

--- a/libsrc/core/utils.hpp
+++ b/libsrc/core/utils.hpp
@@ -19,7 +19,9 @@
 #ifdef NETGEN_ARCH_AMD64
 #ifdef WIN32
 #include <intrin.h>   // for __rdtsc()  CPU time step counter
-#else
+#define NGCORE_HAVE_RDTSC
+#elif defined __SSE__
+#define NGCORE_HAVE_RDTSC
 #include <x86intrin.h>   // for __rdtsc()  CPU time step counter
 #endif // WIN32
 #endif // NETGEN_ARCH_AMD64
@@ -65,7 +67,7 @@ namespace ngcore
   {
 #if defined(__APPLE__) && defined(NETGEN_ARCH_ARM64)
     return mach_absolute_time();
-#elif defined(NETGEN_ARCH_AMD64)
+#elif defined(NETGEN_ARCH_AMD64) || defined(NGCORE_HAVE_RDTSC)
     return __rdtsc();
 #elif defined(NETGEN_ARCH_ARM64) && defined(__GNUC__)
     // __GNUC__ is also defined by CLANG. Use inline asm to read Generic Timer
@@ -74,6 +76,8 @@ namespace ngcore
     return tics;
 #elif defined(__EMSCRIPTEN__)
     return std::chrono::high_resolution_clock::now().time_since_epoch().count();
+#elifndef NGCORE_HAVE_RDTSC
+    return TTimePoint(std::chrono::steady_clock::now().time_since_epoch().count());
 #else
 #warning "Unsupported CPU architecture"
     return 0;

--- a/python/pyngcore/__init__.py
+++ b/python/pyngcore/__init__.py
@@ -1,1 +1,7 @@
 from .pyngcore import *
+
+# <size_t> is the same as <unsigned int> on 32 bit arches
+# in which case Array_I_S is not defined by python_ngcore_export.cpp.
+# In this case identify it with Array_I_U.
+try: Array_I_S
+except NameError: Array_I_S=Array_I_U


### PR DESCRIPTION
On 32-bit systems size_t is identical unsigned in, causing  redefinition errors in tables (Array_I_S).
    
This patch guards against the 32-bit redefinition and defines
Array_I_S = Array_I_U for the python interface if not already defined.
    
Applies debian patch size_t_int32.patch
https://salsa.debian.org/science-team/netgen/-/blob/d7ca1c564d90d00ce3d83e0b63c36fbec11cf1ce/debian/patches/size_t_int32.patch

Also applies debian patch support-non-x86.patch
https://salsa.debian.org/science-team/netgen/-/blob/d7ca1c564d90d00ce3d83e0b63c36fbec11cf1ce/debian/patches/support-non-x86.patch
to support non-intel archictectures missing RDTSC.

Fixes #168
