### PR TITLE
fix linker error due to export macro

### DIFF
--- a/libsrc/core/bitarray.hpp
+++ b/libsrc/core/bitarray.hpp
@@ -226,7 +226,7 @@ private:
     
     bool operator[] (IndexType i) const { return Test(i); } 
     T_Range<IndexType> Range() const { return { IndexBASE<IndexType>(), IndexBASE<IndexType>()+Size() }; }
-    NGCORE_API TBitArray & Or (const TBitArray & ba2)
+    inline TBitArray & Or (const TBitArray & ba2)
     {
       BitArray::Or(ba2);
       return *this;


### PR DESCRIPTION
this small fix was needed to build netgen with VS 2022.