### PR TITLE
Initailize python interpreter before getting GIL

### DIFF
--- a/libsrc/core/python_ngcore.hpp
+++ b/libsrc/core/python_ngcore.hpp
@@ -2,6 +2,7 @@
 #define NETGEN_CORE_PYTHON_NGCORE_HPP
 
 #include "ngcore_api.hpp" // for operator new
+#include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 #include <pybind11/numpy.h>

--- a/ng/ngappinit.cpp
+++ b/ng/ngappinit.cpp
@@ -256,6 +256,7 @@ int main(int argc, char ** argv)
       Tk_MainLoop();
       Tcl_DeleteInterp (myinterp); 
 #ifdef NETGEN_PYTHON
+      py::scoped_interpreter guard{};
       py::gil_scoped_acquire ensure_gil;
 #endif
 


### PR DESCRIPTION
Should fix segfault when exit netgen main program. See https://github.com/NGSolve/netgen/issues/209

Distro compile netgen main program as a standalone app, so we should make sure python interpreter initialized before getting GIL. This error will not be catched by your offical pypi release whereas netgen is a python script and python interpreter always get initialized.