### PR TITLE
Fix: Preserve periodic BC identifications in MergeMeshes

### DIFF
--- a/libsrc/meshing/meshfunc.cpp
+++ b/libsrc/meshing/meshfunc.cpp
@@ -557,7 +557,9 @@ namespace netgen
      }
 
      mesh.VolumeElements().DeleteAll();
-     mesh.GetIdentifications().GetIdentifiedPoints().DeleteData();
+     // Note: Do not delete identification points here - the original mesh contains
+     // identifications set before meshing (e.g., via Identify+Glue), while subdomain
+     // meshes typically do not have them. Deleting here loses periodic BC info.
 
      for(auto & m_ : md)
      {


### PR DESCRIPTION
## Summary
- Fix regression where periodic boundary conditions set via `Identify()` + `Glue()` are lost during volume meshing

## Problem
The `DeleteData()` call on identification points was introduced in commit 27b8b5e7 ("Fix handling identified points in Compress and MeshVolume").

However, this causes a regression where periodic boundary conditions set via `Identify()` + `Glue()` are lost during volume meshing. The issue is that the original mesh contains the identification information, but when merging subdomain meshes, this information is deleted before subdomain identifications (which typically don't exist) are copied.

## Solution
Remove the `DeleteData()` call, preserving the original mesh's identification points. The subsequent loop still copies any subdomain identifications if they exist.

## Test case
```python
from netgen.occ import *

box1 = Box(gp_Pnt(0,0,0), gp_Pnt(1,1,1))
box2 = Box(gp_Pnt(2,0,0), gp_Pnt(3,1,1))
box1.faces[0].Identify(box2.faces[0], 'periodic', IdentificationType.PERIODIC)
shape = Glue([box1, box2])
geo = OCCGeometry(shape)
mesh = geo.GenerateMesh(maxh=0.5)
print(len(mesh.GetIdentifications()))  # Should be > 0, was 0 before fix
```

## Related
- Forum issue: https://ngsolve.org/forum/ngspy-forum/1918-periodic-b-c-regression
- Bug introduced in: 27b8b5e7c8156231a39537f178eb1d252d20e0a4

🤖 Generated with [Claude Code](https://claude.ai/code)