### PR TITLE
netgen: fix UB in Archive::operator&

### DIFF
--- a/libsrc/core/archive.hpp
+++ b/libsrc/core/archive.hpp
@@ -327,7 +327,7 @@ namespace ngcore
       (*this) & size;
       if(Input())
         v.resize(size);
-      Do(&v[0], size);
+      Do(v.data(), size);
       return (*this);
     }
  


### PR DESCRIPTION
Hi, this pr aims to fix the undefined behavior in ngcore::archive::operator& when size==0.
The bug was discovered in Nixpkgs when doing test on aarch64-darwin.

You can reproduce this bug compiling with "-D_GLIBCXX_ASSERTIONS".  