### PR TITLE
fix: GetStatus shows current task name of mesh generation from ngsolve when called from ngsolve.

### DIFF
--- a/libsrc/core/statushandler.cpp
+++ b/libsrc/core/statushandler.cpp
@@ -95,17 +95,23 @@ namespace ngcore
   }
 
 
-  void GetStatus(std::string & s, double & percentage)
+  void GetStatus (std::string& s, double& percentage)
   {
-    if(threadpercent_stack.Size() > 0)
+    if (threadpercent_stack.Size() > 0)
       percentage = threadpercent_stack.Last();
     else
       percentage = multithread.percent;
-    
-    if ( msgstatus_stack.Size() )
+
+    if (msgstatus_stack.Size())
       s = msgstatus_stack.Last();
     else
-      s = "idle";     
+      {
+        // netgen writes directly to multithread.task
+        if (percentage > 0.0)
+          s = multithread.task;
+        else
+          s = "idle";
+      }
   }
 }
 


### PR DESCRIPTION
Problem:
When called GetStatus from ngsolve python code to monitor mesh generating, task name is 'idle' and percent is changed.

Solution:
Because netgen writes task name directly to multithread.task and does not use msgstatus_stack, task name of netgen is not correctly displayed. So I implemented change.