### PR TITLE
Convert prism6 to prism15 if second order is applied

### DIFF
--- a/libsrc/meshing/secondorder.cpp
+++ b/libsrc/meshing/secondorder.cpp
@@ -283,7 +283,6 @@ namespace netgen
 	      onp = 4;
 	      break;
 	    }
-	  case PRISM:
 	  case PRISM12:
 	    {
 	      betw = betw_prism;
@@ -291,6 +290,7 @@ namespace netgen
 	      onp = 6;
 	      break;
 	    }
+          case PRISM:
           case PRISM15:
             {
               betw = betw_prism15;


### PR DESCRIPTION
Convert 6-node prism to 15-node prism if second order is applied.

Currently, the 6-node prism is converted to 12-node prism. This is problematic, if for example, the mesh is generated by extrusion with Z-refinement from a quad dominated mesh: 20-node hexahedrons are generated from the quads, while the triangles generate 12-node prisms, so the mid-height nodes of the hexahedrons are not shared with the prisms.