### PR TITLE
fix(stlgeom): export STLMeshingDummy with DLL_HEADER

### DIFF
--- a/libsrc/stlgeom/stlgeom.hpp
+++ b/libsrc/stlgeom/stlgeom.hpp
@@ -484,7 +484,7 @@ namespace netgen
 
 
 
-extern int STLMeshingDummy (STLGeometry* stlgeometry, shared_ptr<Mesh> & mesh, const MeshingParameters & mparam,
+DLL_HEADER extern int STLMeshingDummy (STLGeometry* stlgeometry, shared_ptr<Mesh> & mesh, const MeshingParameters & mparam,
                             const STLParameters& stlpar);
 
 


### PR DESCRIPTION
STLMeshingDummy is the free function that lets a caller supply a custom STLParameters when meshing an STL geometry (bypassing the global stlparam singleton that STLGeometry::GenerateMesh hardcodes) -- it's what upstream's own Python bindings (python_stl.cpp) call for exactly this reason. Its declaration in stlgeom.hpp had no DLL_HEADER export macro, unlike virtually every other public free function in this codebase (see e.g. general/template.hpp, meshing/boundarylayer.hpp, meshing/bisect.hpp for the established "DLL_HEADER extern <type> Name(...)" convention).

Practical effect: on a shared-library build with default-hidden visibility, this symbol is compiled into stlgeommesh.cpp's object file but not exported from the resulting .dylib/.so, so any external binding layer linking against Netgen's public shared library gets an undefined-symbol error at link time when trying to call it directly, even though the header declares it as callable.