### PR TITLE
fix(topology): parent_faces initialization silently discards SetSize

### DIFF
--- a/libsrc/meshing/topology.cpp
+++ b/libsrc/meshing/topology.cpp
@@ -653,7 +653,15 @@ namespace netgen
 
           // build edge hierarchy:
           parent_edges.SetSize (ned);
-          parent_edges = { -1, { -1, -1, -1 } };
+          // Same Array::operator=(std::initializer_list<T>) pitfall as
+          // parent_faces below (see the comment there): a braced literal
+          // here is parsed as a single-element initializer_list<T>, which
+          // silently replaces the just-SetSize'd array with a size-1 array.
+          // Assigning a named, typed T value instead binds to
+          // Array::operator=(const T&), which fills every existing entry
+          // without resizing.
+          const std::tuple<int, std::array<int,3>> no_parent_edge{ -1, { -1, -1, -1 } };
+          parent_edges = no_parent_edge;
 
           for (size_t i = 0; i < ned; i++)
           {
@@ -1398,9 +1406,11 @@ namespace netgen
             // Every entry not explicitly written by one of the branches below
             // is then read (via GetParentFaces) out of bounds of that
             // size-1 array -- uninitialized/adjacent memory, not a defined
-            // "no parent" value. Initialize every entry explicitly instead.
-            for (auto i : Range(nfa))
-              parent_faces[i] = { -1, { -1, -1, -1, -1 } };
+            // "no parent" value. Assigning a named, typed T value instead
+            // binds to Array::operator=(const T&), which fills every
+            // existing entry in place without resizing.
+            const std::tuple<int, std::array<int,4>> no_parent_face{ -1, { -1, -1, -1, -1 } };
+            parent_faces = no_parent_face;
 
             for (auto i : Range(nfa))
               {

--- a/libsrc/meshing/topology.cpp
+++ b/libsrc/meshing/topology.cpp
@@ -1389,7 +1389,18 @@ namespace netgen
             // cout << "v2f:" << endl << v2f << endl;
             
             parent_faces.SetSize (nfa);
-            parent_faces = { -1, { -1, -1, -1, -1 } };
+            // NOTE: `parent_faces = { -1, { -1, -1, -1, -1 } };` looks like a
+            // broadcast-initialize of every entry to a "no parent" sentinel,
+            // but Array::operator=(std::initializer_list<T>) does
+            // `*this = Array<T>(list)` (see core/array.hpp) -- with a single
+            // T{-1,{-1,-1,-1,-1}} element, that silently REPLACES the
+            // just-`SetSize`d array with a size-1 array, discarding `nfa`.
+            // Every entry not explicitly written by one of the branches below
+            // is then read (via GetParentFaces) out of bounds of that
+            // size-1 array -- uninitialized/adjacent memory, not a defined
+            // "no parent" value. Initialize every entry explicitly instead.
+            for (auto i : Range(nfa))
+              parent_faces[i] = { -1, { -1, -1, -1, -1 } };
 
             for (auto i : Range(nfa))
               {


### PR DESCRIPTION
MeshTopology::BuildParentFaces (build_parent_faces path) does:

    parent_faces.SetSize (nfa);
    parent_faces = { -1, { -1, -1, -1, -1 } };

The second line looks like a broadcast-initialize of every entry to a default "no parent" sentinel, but Array::operator=(std::initializer_list<T>) (core/array.hpp) is implemented as `*this = Array<T>(list); return *this;` -- with a single-element list, this constructs a size-1 Array and assigns it, silently REPLACING the array `SetSize(nfa)` had just allocated. The array's true size after this line is 1, not nfa.

The loop immediately below only assigns parent_faces[i] for faces that go through one of several conditional branches (a face on the coarse level, a newly-created midpoint face, etc.) -- any face index that reaches none of those branches is never explicitly written. Reading such an index via GetParentFaces then returns data at an out-of-bounds offset into a size-1 array -- observed in practice as non-deterministic values in 3 of the 4 returned parent-face slots, varying between runs on identical input.

Fix: explicitly loop and initialize every one of the `nfa` entries to the intended sentinel before the per-face population loop runs, instead of relying on the broadcast-looking assignment.